### PR TITLE
wifi_config_t struct not initialized

### DIFF
--- a/MatrixVoiceAudioServer/main/network.c
+++ b/MatrixVoiceAudioServer/main/network.c
@@ -105,7 +105,7 @@ void networkConnect(const char *ssid, const char *password)
     ESP_ERROR_CHECK( esp_wifi_init(&wlanInitConfig) );
     ESP_ERROR_CHECK( esp_wifi_set_storage(WIFI_STORAGE_RAM) );
 
-    wifi_config_t wlanStaConfig;
+    wifi_config_t wlanStaConfig = {};
     strcpy((char *)wlanStaConfig.sta.ssid, ssid);
     strcpy((char *)wlanStaConfig.sta.password, password);
 


### PR DESCRIPTION
I was getting SYSTEM_EVENT_STA_DISCONNECTED errors. Apparently the wifi config wasn't set. This fixed it for me.