### PR TITLE
added modelId to mqtt message, as snips requires it

### DIFF
--- a/MatrixVoiceAudioServer/config.h
+++ b/MatrixVoiceAudioServer/config.h
@@ -4,6 +4,7 @@
 #define MQTT_PASS "MQTTPassword"
 
 #define SITEID "matrixvoice"
+#define MODELID "alexa"
 //Change to your own IP
 #define MQTT_IP IPAddress(192, 168, 43, 54)
 #define MQTT_HOST "192.168.43.54"

--- a/PlatformIO/platformio.ini
+++ b/PlatformIO/platformio.ini
@@ -16,6 +16,7 @@ build_flags =
    '-DWIFI_PASS="password"'                 ; Change to your wifi password
    '-DHOSTNAME="192.168.43.140"'            ; Should match above upload_port
    '-DSITEID="matrixvoice"'                 ; siteid is part of the MQTT topic
+   '-DMODELID="alexa"'                      ; modelid is part of the MQTT topic
    '-DOTA_PASS_HASH="createmd5hash"'        ; hashed with MD5 https://www.md5hashgenerator.com/
    '-DMQTT_IP=IPAddress(192, 168, 43, 54)'  ; Change to the IP of your MQTT broker
    '-DMQTT_HOST="192.168.43.54"'            ; Change to the IP of your MQTT broker

--- a/PlatformIO/src/MatrixVoiceAudioServer.cpp
+++ b/PlatformIO/src/MatrixVoiceAudioServer.cpp
@@ -616,7 +616,7 @@ void Audiostream(void *p) {
                     
                     int r = wakenet->detect(model_data, voicebuffer_wk);
                     if (r > 0) {
-                        detectMsg =  std::string("{\"siteId\":\"") + SITEID + std::string("\"}");
+                        detectMsg =  std::string("{\"siteId\":\"") + SITEID + std::string("\", \"modelId\":\"") + MODELID + std::string("\"}");
                         asyncClient.publish(hotwordDetectedTopic.c_str(), 0, false, detectMsg.c_str());
                         hotword_detected = true;
                         publishDebug("Hotword Detected");


### PR DESCRIPTION
siteId alone is not sufficient, if the wakeword module is used on the esp.